### PR TITLE
Randomize pod name to support multiple forwards

### DIFF
--- a/net-forward
+++ b/net-forward
@@ -131,7 +131,7 @@ else
 fi
 
 # Random pod name
-PODNAME=net-forward-socat
+PODNAME="net-forward-socat-$(env LC_ALL=C tr -dc a-z0-9 </dev/urandom | head -c 6)"
 
 # Deploy socat pod
 kubectl ${NAMESPACECMD} run --restart=Never --image=alpine/socat ${PODNAME} -- -d -d tcp-listen:${LISTENER},fork,reuseaddr tcp-connect:${IP}:${PORT}


### PR DESCRIPTION
To date a fixed pod name has been used which only allows for a single port forward within the context of a given cluster. This change randomizes the pod name such that multiple port forwards can be established per targeted cluste.

cc: @antitree 