### PR TITLE
Add release automation for krew plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Build package
+        run: |
+          make package VERSION=${VERSION}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: net-forward-${{ env.VERSION }}
+          path: |
+            net-forward_*.tar.gz
+            net-forward_*.tar.gz.sha256
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            net-forward_*.tar.gz
+            net-forward_*.tar.gz.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+net-forward_*.tar.gz
+net-forward_*.tar.gz.sha256

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.RECIPEPREFIX := >
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)
+PLUGIN := net-forward
+DIST_DIR := dist
+BUILD_DIR := $(DIST_DIR)/$(VERSION)
+TARBALL := $(PLUGIN)_$(VERSION).tar.gz
+MANIFEST_OWNER ?= REPO_OWNER
+
+.PHONY: all clean build package manifest
+
+all: package manifest
+
+build:
+>mkdir -p $(BUILD_DIR)
+>cp $(PLUGIN) $(BUILD_DIR)/
+
+package: build
+>tar -czf $(TARBALL) -C $(BUILD_DIR) $(PLUGIN)
+>sha256sum $(TARBALL) > $(TARBALL).sha256
+
+manifest: package
+>mkdir -p $(DIST_DIR)
+>./scripts/update-manifest.sh $(VERSION) $(shell cut -d' ' -f1 $(TARBALL).sha256) $(MANIFEST_OWNER)
+
+clean:
+>rm -rf $(DIST_DIR) $(PLUGIN)_*.tar.gz $(PLUGIN)_*.tar.gz.sha256

--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ of things. I personnly like doing it because I have all of my favorite testing t
 laptop and now can just point it another service in the cluster without having to tool up a Pod
 or deploy a custom image. 
 
+
+## Release workflow
+
+Releases are created from git tags. Once a tag that starts with `v` is pushed,
+GitHub Actions builds a tarball that contains the plugin script and attaches it
+to the GitHub release. The version of the release is taken from the tag name.
+
+To produce a new release:
+
+1. Update the repository as needed and commit the changes.
+2. Create a new tag following the `v<major>.<minor>.<patch>` pattern, e.g.
+   `git tag v1.2.3`.
+3. Push the tag to GitHub: `git push origin v1.2.3`.
+
+The workflow packages `net-forward` into `net-forward_<version>.tar.gz` and
+publishes it with the release. This artifact can be referenced from the
+krew-index repository.

--- a/krew-plugin.yaml
+++ b/krew-plugin.yaml
@@ -1,0 +1,22 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: net-forward
+spec:
+  version: {{VERSION}}
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/{{REPO_OWNER}}/krew-net-forward/releases/download/{{VERSION}}/net-forward_{{VERSION}}.tar.gz
+    sha256: {{SHA256}}
+    files:
+    - from: net-forward
+      to: .
+    bin: net-forward
+    shortDesc: Forward to arbitrary cluster endpoints
+    description: |
+      net-forward lets you create a local TCP listener that forwards
+      traffic to any reachable IP inside the Kubernetes cluster.
+    homepage: https://github.com/{{REPO_OWNER}}/krew-net-forward

--- a/scripts/update-manifest.sh
+++ b/scripts/update-manifest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=${1:?"version required"}
+SHA256=${2:?"sha256 required"}
+OWNER=${3:-REPO_OWNER}
+
+sed \
+  -e "s/{{VERSION}}/${VERSION}/g" \
+  -e "s/{{REPO_OWNER}}/${OWNER}/g" \
+  -e "s/{{SHA256}}/${SHA256}/g" \
+  krew-plugin.yaml > dist/net-forward.yaml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for tag-based releases
- add Makefile to package plugin and generate krew manifest
- add script to fill manifest template
- document release workflow in README
- add krew plugin manifest template

## Testing
- `make package`
- `make manifest MANIFEST_OWNER=testowner`

------
https://chatgpt.com/codex/tasks/task_e_6877b05e769c832c9bbc3fb0365fc8c2