### PR TITLE
Include LICENSE file in release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ all: package manifest
 build:
 >mkdir -p $(BUILD_DIR)
 >cp $(PLUGIN) $(BUILD_DIR)/
+>cp LICENSE $(BUILD_DIR)/
 
 package: build
->tar -czf $(TARBALL) -C $(BUILD_DIR) $(PLUGIN)
+>tar -czf $(TARBALL) -C $(BUILD_DIR) $(PLUGIN) LICENSE
 >sha256sum $(TARBALL) > $(TARBALL).sha256
 
 manifest: package

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ or deploy a custom image.
 ## Release workflow
 
 Releases are created from git tags. Once a tag that starts with `v` is pushed,
-GitHub Actions builds a tarball that contains the plugin script and attaches it
+GitHub Actions builds a tarball that contains the plugin script and `LICENSE`
+file and attaches it
 to the GitHub release. The version of the release is taken from the tag name.
 
 To produce a new release:
@@ -82,6 +83,6 @@ To produce a new release:
    `git tag v1.2.3`.
 3. Push the tag to GitHub: `git push origin v1.2.3`.
 
-The workflow packages `net-forward` into `net-forward_<version>.tar.gz` and
+The workflow packages `net-forward` and `LICENSE` into `net-forward_<version>.tar.gz` and
 publishes it with the release. This artifact can be referenced from the
 krew-index repository.


### PR DESCRIPTION
## Summary
- include LICENSE in build output and tarball
- document LICENSE in the release workflow

## Testing
- `make package VERSION=0.1.0`

------
https://chatgpt.com/codex/tasks/task_e_6877fda19678832ca592f1d506811a28